### PR TITLE
django.utils.unittest has been removed in Django 1.9

### DIFF
--- a/geoip_utils/utils.py
+++ b/geoip_utils/utils.py
@@ -1,4 +1,8 @@
-from django.utils.importlib import import_module
+import django
+if django.VERSION < (1, 9):
+    from django.utils.importlib import import_module
+else:
+    from importlib import import_module
 from django.core.exceptions import ImproperlyConfigured
 
 from .settings import REQUEST_IP_RESOLVER


### PR DESCRIPTION
compare to https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9
